### PR TITLE
chore: overhaul dependabot config and pin CI actions to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,30 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 2
+    groups:
+      # Actions are numerous and generate noisy PRs, so bundle them into one.
+      # All actions are SHA-pinned, so minor/patch updates are meaningful too.
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 2
+    groups:
+      # Bundle minor/patch into one PR to cut review overhead (major stays separate).
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
+      # @types/node is pinned to the Node runtime major (see mise.toml: node 24).
+      # No need for v25+ types until the runtime itself is upgraded.
       - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
           cache: true
@@ -20,7 +20,7 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `groups` (github-actions bundled, npm minor/patch bundled) and `cooldown` to `.github/dependabot.yml` to cut Dependabot PR noise
- Pin `actions/checkout` and `jdx/mise-action` to SHA in `.github/workflows/test.yml` so Dependabot can track minor/patch updates too (not just major)
- Reformat the existing `@types/node` major-version ignore and document why it's tied to the `mise.toml` node version

## Test plan
- [x] Validated YAML syntax of `dependabot.yml` and `test.yml`
- [x] Verified pinned SHAs resolve to the intended tags via the GitHub API
- [ ] Confirm CI passes on this PR

<!-- start changed-lines-number-action -->
### [Changes Lines](https://github.com/aki77/changed-lines-number-action)
_+23 additions, -4 deletions_

| Language | Line Ratio | Files | Additions | Deletions |
| :------- | ---------: | ----: | --------: | --------: |
| YAML     |       100% |     2 |       +23 |        -4 |
<!-- end changed-lines-number-action -->