### PR TITLE
fix: grant pull-requests write permission to test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       - run: pnpm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Dependabot PRs get a read-only GITHUB_TOKEN by default; this action
+      # updates the PR body, so pull-requests: write must be granted explicitly.
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./


### PR DESCRIPTION
## Summary
- Fixes the `test` job in Dependabot PR (#238) failing with `403 Resource not accessible by integration`
- Dependabot PRs get a read-only `GITHUB_TOKEN` by default, so the job verifying this action (which updates the PR body) failed to write. Explicitly declaring `permissions` grants `pull-requests: write`.

## Test plan
- [ ] After merging, rebase Dependabot PR #238 and confirm the `test` job passes

<!-- start changed-lines-number-action -->
### [Changes Lines](https://github.com/aki77/changed-lines-number-action)
_+5 additions, -0 deletions_

| Language | Line Ratio | Files | Additions | Deletions |
| :------- | ---------: | ----: | --------: | --------: |
| YAML     |       100% |     1 |        +5 |        -0 |
<!-- end changed-lines-number-action -->